### PR TITLE
Add C# game translation skeleton

### DIFF
--- a/GameTranslator.sln
+++ b/GameTranslator.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameTranslator.App", "src\GameTranslator.App\GameTranslator.App.csproj", "{398C8677-ED37-484C-A77E-2DA4AE59A1A4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameTranslator.Core", "src\GameTranslator.Core\GameTranslator.Core.csproj", "{BB9498EA-D05B-4110-8093-0716173F476E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameTranslator.Infrastructure", "src\GameTranslator.Infrastructure\GameTranslator.Infrastructure.csproj", "{F38EAA3E-257F-40F6-BACC-745668D85F61}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameTranslator.Tests", "src\GameTranslator.Tests\GameTranslator.Tests.csproj", "{E618298B-CD68-47FC-AB64-4B00B1A32DAF}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# TranslateTool
+# GameTranslator
+
+This repository provides a skeleton for a real-time game translation tool written in **C#** using WPF and the MVVM architecture. The solution includes separate projects for the application UI, core interfaces, infrastructure services, and unit tests.
+
+## Projects
+- **GameTranslator.App** - WPF front-end application.
+- **GameTranslator.Core** - Core abstractions and models.
+- **GameTranslator.Infrastructure** - Implementations for translation, OCR, and caching with dependency injection helpers.
+- **GameTranslator.Tests** - Example unit tests using xUnit and Moq.
+
+## Build
+```bash
+# Restore dependencies
+ dotnet restore GameTranslator.sln
+# Run tests
+ dotnet test GameTranslator.sln
+```
+
+The solution targets **.NET 8**. WPF applications require Windows to run; building on non-Windows hosts may need the Windows desktop SDK.

--- a/src/GameTranslator.App/App.xaml
+++ b/src/GameTranslator.App/App.xaml
@@ -1,0 +1,4 @@
+<Application x:Class="GameTranslator.App" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/src/GameTranslator.App/App.xaml.cs
+++ b/src/GameTranslator.App/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace GameTranslator
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/src/GameTranslator.App/GameTranslator.App.csproj
+++ b/src/GameTranslator.App/GameTranslator.App.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GameTranslator.Core\GameTranslator.Core.csproj" />
+    <ProjectReference Include="..\GameTranslator.Infrastructure\GameTranslator.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/GameTranslator.App/MainWindow.xaml
+++ b/src/GameTranslator.App/MainWindow.xaml
@@ -1,0 +1,5 @@
+<Window x:Class="GameTranslator.MainWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Title="Game Translator" Height="350" Width="525">
+    <Grid>
+        <TextBlock Text="Real-time Game Translator" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</Window>

--- a/src/GameTranslator.App/MainWindow.xaml.cs
+++ b/src/GameTranslator.App/MainWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace GameTranslator
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/GameTranslator.Core/GameTranslator.Core.csproj
+++ b/src/GameTranslator.Core/GameTranslator.Core.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/src/GameTranslator.Core/Models/TextContext.cs
+++ b/src/GameTranslator.Core/Models/TextContext.cs
@@ -1,0 +1,4 @@
+namespace GameTranslator.Core.Models
+{
+    public record TextContext(string SourceText, string Context);
+}

--- a/src/GameTranslator.Core/Services/ICacheService.cs
+++ b/src/GameTranslator.Core/Services/ICacheService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace GameTranslator.Core.Services
+{
+    public interface ICacheService
+    {
+        Task<string?> GetAsync(string key);
+        Task SetAsync(string key, string value);
+    }
+}

--- a/src/GameTranslator.Core/Services/ITextCaptureService.cs
+++ b/src/GameTranslator.Core/Services/ITextCaptureService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace GameTranslator.Core.Services
+{
+    public interface ITextCaptureService
+    {
+        Task<string?> CaptureTextAsync();
+    }
+}

--- a/src/GameTranslator.Core/Services/ITranslationService.cs
+++ b/src/GameTranslator.Core/Services/ITranslationService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace GameTranslator.Core.Services
+{
+    public interface ITranslationService
+    {
+        Task<string> TranslateAsync(string text, string targetLanguage);
+    }
+}

--- a/src/GameTranslator.Infrastructure/GameTranslator.Infrastructure.csproj
+++ b/src/GameTranslator.Infrastructure/GameTranslator.Infrastructure.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GameTranslator.Core\GameTranslator.Core.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/GameTranslator.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/GameTranslator.Infrastructure/ServiceCollectionExtensions.cs
@@ -1,0 +1,19 @@
+using System.Net.Http;
+using GameTranslator.Core.Services;
+using GameTranslator.Infrastructure.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GameTranslator.Infrastructure
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddGameTranslator(this IServiceCollection services)
+        {
+            services.AddSingleton<HttpClient>();
+            services.AddSingleton<ICacheService, MemoryCacheService>();
+            services.AddSingleton<ITranslationService, TranslationService>();
+            services.AddSingleton<ITextCaptureService, OcrTextCaptureService>();
+            return services;
+        }
+    }
+}

--- a/src/GameTranslator.Infrastructure/Services/MemoryCacheService.cs
+++ b/src/GameTranslator.Infrastructure/Services/MemoryCacheService.cs
@@ -1,0 +1,23 @@
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using GameTranslator.Core.Services;
+
+namespace GameTranslator.Infrastructure.Services
+{
+    public class MemoryCacheService : ICacheService
+    {
+        private readonly ConcurrentDictionary<string, string> _cache = new();
+
+        public Task<string?> GetAsync(string key)
+        {
+            _cache.TryGetValue(key, out var value);
+            return Task.FromResult<string?>(value);
+        }
+
+        public Task SetAsync(string key, string value)
+        {
+            _cache[key] = value;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/GameTranslator.Infrastructure/Services/OcrTextCaptureService.cs
+++ b/src/GameTranslator.Infrastructure/Services/OcrTextCaptureService.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+using GameTranslator.Core.Services;
+
+namespace GameTranslator.Infrastructure.Services
+{
+    public class OcrTextCaptureService : ITextCaptureService
+    {
+        public Task<string?> CaptureTextAsync()
+        {
+            // TODO: Implement OCR text capture from game window
+            return Task.FromResult<string?>(null);
+        }
+    }
+}

--- a/src/GameTranslator.Infrastructure/Services/TranslationService.cs
+++ b/src/GameTranslator.Infrastructure/Services/TranslationService.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using GameTranslator.Core.Services;
+
+namespace GameTranslator.Infrastructure.Services
+{
+    public class TranslationService : ITranslationService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly ICacheService _cache;
+
+        public TranslationService(HttpClient httpClient, ICacheService cache)
+        {
+            _httpClient = httpClient;
+            _cache = cache;
+        }
+
+        public async Task<string> TranslateAsync(string text, string targetLanguage)
+        {
+            var cacheKey = $"{text}_{targetLanguage}";
+            var cached = await _cache.GetAsync(cacheKey);
+            if (cached != null)
+            {
+                return cached;
+            }
+
+            var response = await _httpClient.GetAsync($"https://api.example.com/translate?text={Uri.EscapeDataString(text)}&lang={targetLanguage}");
+            response.EnsureSuccessStatusCode();
+            var result = await response.Content.ReadAsStringAsync();
+            var doc = JsonDocument.Parse(result);
+            var translated = doc.RootElement.GetProperty("translatedText").GetString() ?? string.Empty;
+            await _cache.SetAsync(cacheKey, translated);
+            return translated;
+        }
+    }
+}

--- a/src/GameTranslator.Tests/GameTranslator.Tests.csproj
+++ b/src/GameTranslator.Tests/GameTranslator.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GameTranslator.Core\GameTranslator.Core.csproj" />
+    <ProjectReference Include="..\GameTranslator.Infrastructure\GameTranslator.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/GameTranslator.Tests/Services/TranslationServiceTests.cs
+++ b/src/GameTranslator.Tests/Services/TranslationServiceTests.cs
@@ -1,0 +1,39 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GameTranslator.Core.Services;
+using GameTranslator.Infrastructure.Services;
+using Moq;
+using Xunit;
+
+namespace GameTranslator.Tests.Services
+{
+    public class TranslationServiceTests
+    {
+        [Fact]
+        public async Task TranslateAsync_UsesCache_WhenAvailable()
+        {
+            var cacheMock = new Mock<ICacheService>();
+            cacheMock.Setup(c => c.GetAsync("hello_en")).ReturnsAsync("hi");
+            var httpClient = new HttpClient(new HttpMessageHandlerStub());
+            var service = new TranslationService(httpClient, cacheMock.Object);
+
+            var result = await service.TranslateAsync("hello", "en");
+
+            Assert.Equal("hi", result);
+            cacheMock.Verify(c => c.GetAsync("hello_en"), Times.Once);
+        }
+    }
+
+    internal class HttpMessageHandlerStub : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"translatedText\":\"hi\"}")
+            };
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a solution with WPF app and library projects
- implement translation service, caching and DI helpers
- provide xUnit test for cache usage
- update README with build instructions

## Testing
- `dotnet restore src/GameTranslator.Core/GameTranslator.Core.csproj`
- `dotnet restore src/GameTranslator.Infrastructure/GameTranslator.Infrastructure.csproj`
- `dotnet restore src/GameTranslator.Tests/GameTranslator.Tests.csproj`
- `dotnet test src/GameTranslator.Tests/GameTranslator.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_b_684d9677efc88333b15fa675e720564b