### PR TITLE
Add overlay window service

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,6 @@ This repository provides a skeleton for a real-time game translation tool writte
 ```
 
 The solution targets **.NET 8**. WPF applications require Windows to run; building on non-Windows hosts may need the Windows desktop SDK.
+
+## Overlay Service
+A lightweight overlay window now displays translated text above the game. The `IOverlayService` is registered via dependency injection and can be used to show or hide translations with minimal latency.

--- a/src/GameTranslator.App/App.xaml.cs
+++ b/src/GameTranslator.App/App.xaml.cs
@@ -1,8 +1,23 @@
+using System;
 using System.Windows;
+using GameTranslator.Core.Services;
+using GameTranslator.Services;
+using GameTranslator.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GameTranslator
 {
     public partial class App : Application
     {
+        public static IServiceProvider Services { get; private set; } = null!;
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            var sc = new ServiceCollection();
+            sc.AddGameTranslator();
+            sc.AddSingleton<IOverlayService, OverlayService>();
+            Services = sc.BuildServiceProvider();
+            base.OnStartup(e);
+        }
     }
 }

--- a/src/GameTranslator.App/MainWindow.xaml
+++ b/src/GameTranslator.App/MainWindow.xaml
@@ -1,4 +1,8 @@
-<Window x:Class="GameTranslator.MainWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Title="Game Translator" Height="350" Width="525">
+<Window x:Class="GameTranslator.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Game Translator" Height="350" Width="525"
+        Loaded="Window_Loaded">
     <Grid>
         <TextBlock Text="Real-time Game Translator" HorizontalAlignment="Center" VerticalAlignment="Center"/>
     </Grid>

--- a/src/GameTranslator.App/MainWindow.xaml.cs
+++ b/src/GameTranslator.App/MainWindow.xaml.cs
@@ -1,12 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
 using System.Windows;
+using GameTranslator.Core.Services;
 
 namespace GameTranslator
 {
     public partial class MainWindow : Window
     {
+        private readonly IOverlayService _overlay;
+
         public MainWindow()
         {
             InitializeComponent();
+            _overlay = (IOverlayService)App.Services.GetRequiredService(typeof(IOverlayService));
+        }
+
+        private async void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+            await _overlay.ShowAsync("Translation overlay ready");
         }
     }
 }

--- a/src/GameTranslator.App/OverlayWindow.xaml
+++ b/src/GameTranslator.App/OverlayWindow.xaml
@@ -1,0 +1,9 @@
+<Window x:Class="GameTranslator.OverlayWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        WindowStyle="None" AllowsTransparency="True" Background="Transparent" Topmost="True" ShowInTaskbar="False" ResizeMode="NoResize"  
+        SizeToContent="WidthAndHeight">
+    <Border Background="#AA000000" CornerRadius="4" Padding="8" >
+        <TextBlock x:Name="TextBlock" Foreground="White" FontSize="20"/>
+    </Border>
+</Window>

--- a/src/GameTranslator.App/OverlayWindow.xaml.cs
+++ b/src/GameTranslator.App/OverlayWindow.xaml.cs
@@ -1,0 +1,17 @@
+using System.Windows;
+
+namespace GameTranslator
+{
+    public partial class OverlayWindow : Window
+    {
+        public OverlayWindow()
+        {
+            InitializeComponent();
+        }
+
+        public void SetText(string text)
+        {
+            TextBlock.Text = text;
+        }
+    }
+}

--- a/src/GameTranslator.App/Services/OverlayService.cs
+++ b/src/GameTranslator.App/Services/OverlayService.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using GameTranslator.Core.Services;
+
+namespace GameTranslator.Services
+{
+    public class OverlayService : IOverlayService
+    {
+        private OverlayWindow? _window;
+
+        public Task ShowAsync(string text)
+        {
+            if (_window == null)
+            {
+                _window = new OverlayWindow();
+            }
+            _window.SetText(text);
+            _window.Show();
+            return Task.CompletedTask;
+        }
+
+        public Task HideAsync()
+        {
+            _window?.Hide();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/GameTranslator.Core/Services/IOverlayService.cs
+++ b/src/GameTranslator.Core/Services/IOverlayService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace GameTranslator.Core.Services
+{
+    public interface IOverlayService
+    {
+        Task ShowAsync(string text);
+        Task HideAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- add `IOverlayService` abstraction
- implement `OverlayService` and overlay window in WPF app
- register overlay service via dependency injection
- display sample overlay on application startup
- document overlay service in README

## Testing
- `dotnet restore GameTranslator.sln` *(fails: `dotnet` not found)*
- `dotnet test GameTranslator.sln` *(fails: `dotnet` not found)*


------
https://chatgpt.com/codex/tasks/task_b_684d9af861c48333b6c1c24b544350c5