### PR TITLE
Improve translation context and overlay display

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository provides a skeleton for a real-time game translation tool written in **C#** using WPF and the MVVM architecture. The solution includes separate projects for the application UI, core interfaces, infrastructure services, and unit tests.
 
+The latest update introduces a lightweight overlay window inspired by the [Translumo](https://github.com/Danily07/Translumo) project. Translations are now performed with additional context information to improve accuracy and are displayed directly over the game.
+
 ## Projects
 - **GameTranslator.App** - WPF front-end application.
 - **GameTranslator.Core** - Core abstractions and models.

--- a/src/GameTranslator.App/GameTranslator.App.csproj
+++ b/src/GameTranslator.App/GameTranslator.App.csproj
@@ -7,5 +7,6 @@
   <ItemGroup>
     <ProjectReference Include="..\GameTranslator.Core\GameTranslator.Core.csproj" />
     <ProjectReference Include="..\GameTranslator.Infrastructure\GameTranslator.Infrastructure.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/GameTranslator.App/MainWindow.xaml
+++ b/src/GameTranslator.App/MainWindow.xaml
@@ -1,5 +1,13 @@
 <Window x:Class="GameTranslator.MainWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Title="Game Translator" Height="350" Width="525">
-    <Grid>
-        <TextBlock Text="Real-time Game Translator" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0 0 0 10">
+            <TextBox x:Name="InputBox" Width="300" Margin="0 0 5 0"/>
+            <Button Content="Translate" Width="80" Click="Translate_Click"/>
+        </StackPanel>
+        <TextBlock Text="Real-time Game Translator" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="1"/>
     </Grid>
 </Window>

--- a/src/GameTranslator.App/MainWindow.xaml.cs
+++ b/src/GameTranslator.App/MainWindow.xaml.cs
@@ -1,12 +1,38 @@
 using System.Windows;
+using GameTranslator.Core.Models;
+using GameTranslator.Core.Services;
+using GameTranslator.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GameTranslator
 {
     public partial class MainWindow : Window
     {
+        private readonly ITranslationService _translator;
+        private readonly IOverlayService _overlay;
+
         public MainWindow()
         {
             InitializeComponent();
+
+            var services = new ServiceCollection()
+                .AddGameTranslator()
+                .AddSingleton<IOverlayService, OverlayService>()
+                .BuildServiceProvider();
+
+            _translator = services.GetRequiredService<ITranslationService>();
+            _overlay = services.GetRequiredService<IOverlayService>();
+        }
+
+        private async void Translate_Click(object sender, RoutedEventArgs e)
+        {
+            var text = InputBox.Text;
+            if (string.IsNullOrWhiteSpace(text))
+                return;
+
+            var context = new TextContext(text, string.Empty);
+            var result = await _translator.TranslateAsync(context, "en");
+            await _overlay.ShowAsync(result);
         }
     }
 }

--- a/src/GameTranslator.App/OverlayWindow.xaml
+++ b/src/GameTranslator.App/OverlayWindow.xaml
@@ -1,0 +1,11 @@
+<Window x:Class="GameTranslator.OverlayWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="OverlayWindow"
+        WindowStyle="None" AllowsTransparency="True" Background="Transparent"
+        Topmost="True" ShowInTaskbar="False" ResizeMode="NoResize">
+    <Border Background="#AA000000" CornerRadius="4" Padding="8" >
+        <TextBlock x:Name="TbText" Foreground="White" FontSize="16"/>
+    </Border>
+</Window>
+

--- a/src/GameTranslator.App/OverlayWindow.xaml.cs
+++ b/src/GameTranslator.App/OverlayWindow.xaml.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace GameTranslator
+{
+    public partial class OverlayWindow : Window
+    {
+        private readonly DispatcherTimer _timer;
+
+        public OverlayWindow()
+        {
+            InitializeComponent();
+            _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
+            _timer.Tick += (s, e) => Close();
+        }
+
+        public void ShowText(string text)
+        {
+            TbText.Text = text;
+            Show();
+            _timer.Start();
+        }
+    }
+}
+

--- a/src/GameTranslator.App/Services/OverlayService.cs
+++ b/src/GameTranslator.App/Services/OverlayService.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+using GameTranslator.Core.Services;
+
+namespace GameTranslator
+{
+    public class OverlayService : IOverlayService
+    {
+        public Task ShowAsync(string text)
+        {
+            var window = new OverlayWindow();
+            window.ShowText(text);
+            return Task.CompletedTask;
+        }
+    }
+}
+

--- a/src/GameTranslator.Core/Services/IOverlayService.cs
+++ b/src/GameTranslator.Core/Services/IOverlayService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace GameTranslator.Core.Services
+{
+    public interface IOverlayService
+    {
+        Task ShowAsync(string text);
+    }
+}
+

--- a/src/GameTranslator.Core/Services/ITranslationService.cs
+++ b/src/GameTranslator.Core/Services/ITranslationService.cs
@@ -4,6 +4,12 @@ namespace GameTranslator.Core.Services
 {
     public interface ITranslationService
     {
-        Task<string> TranslateAsync(string text, string targetLanguage);
+        /// <summary>
+        /// Translate the provided text using additional context information.
+        /// </summary>
+        /// <param name="context">Source text and optional surrounding context.</param>
+        /// <param name="targetLanguage">Target language code.</param>
+        /// <returns>Translated text.</returns>
+        Task<string> TranslateAsync(TextContext context, string targetLanguage);
     }
 }

--- a/src/GameTranslator.Infrastructure/Services/TranslationService.cs
+++ b/src/GameTranslator.Infrastructure/Services/TranslationService.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using GameTranslator.Core.Services;
+using GameTranslator.Core.Models;
 
 namespace GameTranslator.Infrastructure.Services
 {
@@ -17,16 +18,17 @@ namespace GameTranslator.Infrastructure.Services
             _cache = cache;
         }
 
-        public async Task<string> TranslateAsync(string text, string targetLanguage)
+        public async Task<string> TranslateAsync(TextContext context, string targetLanguage)
         {
-            var cacheKey = $"{text}_{targetLanguage}";
+            var cacheKey = $"{context.SourceText}_{context.Context}_{targetLanguage}";
             var cached = await _cache.GetAsync(cacheKey);
             if (cached != null)
             {
                 return cached;
             }
 
-            var response = await _httpClient.GetAsync($"https://api.example.com/translate?text={Uri.EscapeDataString(text)}&lang={targetLanguage}");
+            var query = $"https://api.example.com/translate?text={Uri.EscapeDataString(context.SourceText)}&lang={targetLanguage}&context={Uri.EscapeDataString(context.Context)}";
+            var response = await _httpClient.GetAsync(query);
             response.EnsureSuccessStatusCode();
             var result = await response.Content.ReadAsStringAsync();
             var doc = JsonDocument.Parse(result);

--- a/src/GameTranslator.Tests/Services/TranslationServiceTests.cs
+++ b/src/GameTranslator.Tests/Services/TranslationServiceTests.cs
@@ -2,6 +2,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using GameTranslator.Core.Services;
+using GameTranslator.Core.Models;
 using GameTranslator.Infrastructure.Services;
 using Moq;
 using Xunit;
@@ -14,14 +15,15 @@ namespace GameTranslator.Tests.Services
         public async Task TranslateAsync_UsesCache_WhenAvailable()
         {
             var cacheMock = new Mock<ICacheService>();
-            cacheMock.Setup(c => c.GetAsync("hello_en")).ReturnsAsync("hi");
+            cacheMock.Setup(c => c.GetAsync("hello__en")).ReturnsAsync("hi");
             var httpClient = new HttpClient(new HttpMessageHandlerStub());
             var service = new TranslationService(httpClient, cacheMock.Object);
 
-            var result = await service.TranslateAsync("hello", "en");
+            var context = new GameTranslator.Core.Models.TextContext("hello", string.Empty);
+            var result = await service.TranslateAsync(context, "en");
 
             Assert.Equal("hi", result);
-            cacheMock.Verify(c => c.GetAsync("hello_en"), Times.Once);
+            cacheMock.Verify(c => c.GetAsync("hello__en"), Times.Once);
         }
     }
 


### PR DESCRIPTION
## Summary
- add overlay window support inspired by Translumo
- display translation results with `OverlayService`
- translate text with additional context info
- update existing tests for new translation method

## Testing
- `dotnet restore GameTranslator.sln` *(fails: command not found)*
- `dotnet test GameTranslator.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d9af861c48333b6c1c24b544350c5