### PR TITLE
Add Tesseract OCR and overlay support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build outputs
+bin/
+obj/
+# Rider and VS caches
+*.user
+*.suo
+*.userprefs
+*.csproj.nuget.g.props
+*.csproj.nuget.g.targets

--- a/src/GameTranslator.App/MainWindow.xaml.cs
+++ b/src/GameTranslator.App/MainWindow.xaml.cs
@@ -1,12 +1,22 @@
 using System.Windows;
+using GameTranslator.Overlay;
 
 namespace GameTranslator
 {
     public partial class MainWindow : Window
     {
+        private readonly OverlayService _overlay = new();
+
         public MainWindow()
         {
             InitializeComponent();
+            Loaded += MainWindow_Loaded;
+        }
+
+        private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            // Example usage of the overlay: display a welcome message
+            _overlay.ShowText("Translation overlay ready");
         }
     }
 }

--- a/src/GameTranslator.App/Overlay/OverlayService.cs
+++ b/src/GameTranslator.App/Overlay/OverlayService.cs
@@ -1,0 +1,29 @@
+using System.Windows;
+
+namespace GameTranslator.Overlay
+{
+    /// <summary>
+    /// Displays translated text in an always-on-top transparent window.
+    /// </summary>
+    public class OverlayService
+    {
+        private OverlayWindow? _window;
+
+        public void ShowText(string text)
+        {
+            if (_window == null)
+            {
+                _window = new OverlayWindow();
+                _window.Show();
+            }
+
+            _window.OverlayText.Text = text;
+        }
+
+        public void Close()
+        {
+            _window?.Close();
+            _window = null;
+        }
+    }
+}

--- a/src/GameTranslator.App/Overlay/OverlayWindow.xaml
+++ b/src/GameTranslator.App/Overlay/OverlayWindow.xaml
@@ -1,0 +1,8 @@
+<Window x:Class="GameTranslator.Overlay.OverlayWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        WindowStyle="None" AllowsTransparency="True" Background="Transparent"
+        Topmost="True" ShowInTaskbar="False" ResizeMode="NoResize"
+        Width="800" Height="100" Focusable="False">
+    <TextBlock x:Name="OverlayText" FontSize="32" Foreground="White" TextWrapping="Wrap"/>
+</Window>

--- a/src/GameTranslator.App/Overlay/OverlayWindow.xaml.cs
+++ b/src/GameTranslator.App/Overlay/OverlayWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace GameTranslator.Overlay
+{
+    public partial class OverlayWindow : Window
+    {
+        public OverlayWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/GameTranslator.Core/Services/ITranslationService.cs
+++ b/src/GameTranslator.Core/Services/ITranslationService.cs
@@ -5,5 +5,10 @@ namespace GameTranslator.Core.Services
     public interface ITranslationService
     {
         Task<string> TranslateAsync(string text, string targetLanguage);
+
+        /// <summary>
+        /// Translates text using previous context to improve quality.
+        /// </summary>
+        Task<string> TranslateWithContextAsync(string previousText, string text, string targetLanguage);
     }
 }

--- a/src/GameTranslator.Infrastructure/GameTranslator.Infrastructure.csproj
+++ b/src/GameTranslator.Infrastructure/GameTranslator.Infrastructure.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Tesseract" Version="5.0.1" />
     <ProjectReference Include="..\GameTranslator.Core\GameTranslator.Core.csproj" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
   </ItemGroup>

--- a/src/GameTranslator.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/GameTranslator.Infrastructure/ServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace GameTranslator.Infrastructure
             services.AddSingleton<HttpClient>();
             services.AddSingleton<ICacheService, MemoryCacheService>();
             services.AddSingleton<ITranslationService, TranslationService>();
-            services.AddSingleton<ITextCaptureService, OcrTextCaptureService>();
+            services.AddSingleton<ITextCaptureService, TesseractTextCaptureService>();
             return services;
         }
     }

--- a/src/GameTranslator.Infrastructure/Services/TesseractTextCaptureService.cs
+++ b/src/GameTranslator.Infrastructure/Services/TesseractTextCaptureService.cs
@@ -1,0 +1,38 @@
+using System.Drawing;
+using System.IO;
+using System.Threading.Tasks;
+using GameTranslator.Core.Services;
+using Tesseract;
+
+namespace GameTranslator.Infrastructure.Services
+{
+    /// <summary>
+    /// Uses the Tesseract OCR engine to extract text from a screenshot.
+    /// </summary>
+    public class TesseractTextCaptureService : ITextCaptureService
+    {
+        private readonly TesseractEngine _engine;
+
+        public TesseractTextCaptureService()
+        {
+            var dataPath = Path.Combine(Directory.GetCurrentDirectory(), "tessdata");
+            _engine = new TesseractEngine(dataPath, "eng", EngineMode.LstmOnly);
+        }
+
+        public Task<string?> CaptureTextAsync()
+        {
+            // In a real application you would capture the game window here.
+            // For this skeleton we load a sample screenshot if available.
+            const string sample = "sample.png";
+            if (!File.Exists(sample))
+            {
+                return Task.FromResult<string?>(null);
+            }
+
+            using var img = Pix.LoadFromFile(sample);
+            using var page = _engine.Process(img);
+            var text = page.GetText();
+            return Task.FromResult<string?>(text);
+        }
+    }
+}

--- a/src/GameTranslator.Infrastructure/Services/TranslationService.cs
+++ b/src/GameTranslator.Infrastructure/Services/TranslationService.cs
@@ -34,5 +34,17 @@ namespace GameTranslator.Infrastructure.Services
             await _cache.SetAsync(cacheKey, translated);
             return translated;
         }
+
+        /// <summary>
+        /// Translates a phrase using additional context to improve result quality.
+        /// </summary>
+        /// <param name="previousText">Previously translated text that provides context.</param>
+        /// <param name="text">Current text to translate.</param>
+        /// <param name="targetLanguage">Target language code.</param>
+        public async Task<string> TranslateWithContextAsync(string previousText, string text, string targetLanguage)
+        {
+            var combined = string.IsNullOrWhiteSpace(previousText) ? text : previousText + "\n" + text;
+            return await TranslateAsync(combined, targetLanguage);
+        }
     }
 }

--- a/src/GameTranslator.Tests/Services/TranslationServiceTests.cs
+++ b/src/GameTranslator.Tests/Services/TranslationServiceTests.cs
@@ -23,6 +23,18 @@ namespace GameTranslator.Tests.Services
             Assert.Equal("hi", result);
             cacheMock.Verify(c => c.GetAsync("hello_en"), Times.Once);
         }
+
+        [Fact]
+        public async Task TranslateWithContextAsync_CombinesInput()
+        {
+            var cache = new MemoryCacheService();
+            var httpClient = new HttpClient(new HttpMessageHandlerStub());
+            var service = new TranslationService(httpClient, cache);
+
+            var result = await service.TranslateWithContextAsync("hello", "world", "en");
+
+            Assert.Equal("hi", result);
+        }
     }
 
     internal class HttpMessageHandlerStub : HttpMessageHandler


### PR DESCRIPTION
## Summary
- include `.gitignore` for build outputs
- add overlay window and service to display translated text
- implement Tesseract-based text capture service
- allow translation service to use previous context
- wire up new services in DI and update tests

## Testing
- `dotnet test src/GameTranslator.Tests/GameTranslator.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_b_684d9af861c48333b6c1c24b544350c5