### PR TITLE
Add OCR capture service and use LibreTranslate API

### DIFF
--- a/src/GameTranslator.Infrastructure/GameTranslator.Infrastructure.csproj
+++ b/src/GameTranslator.Infrastructure/GameTranslator.Infrastructure.csproj
@@ -6,5 +6,6 @@
     <PackageReference Include="Tesseract" Version="5.0.1" />
     <ProjectReference Include="..\GameTranslator.Core\GameTranslator.Core.csproj" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/GameTranslator.Infrastructure/Services/OcrTextCaptureService.cs
+++ b/src/GameTranslator.Infrastructure/Services/OcrTextCaptureService.cs
@@ -1,14 +1,41 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using SystemDrawingImageFormat = System.Drawing.Imaging.ImageFormat;
+using System.IO;
 using System.Threading.Tasks;
 using GameTranslator.Core.Services;
+using Tesseract;
 
 namespace GameTranslator.Infrastructure.Services
 {
     public class OcrTextCaptureService : ITextCaptureService
     {
+        private readonly TesseractEngine _engine;
+
+        public OcrTextCaptureService()
+        {
+            var dataPath = Path.Combine(Directory.GetCurrentDirectory(), "tessdata");
+            _engine = new TesseractEngine(dataPath, "eng", EngineMode.LstmOnly);
+        }
+
         public Task<string?> CaptureTextAsync()
         {
-            // TODO: Implement OCR text capture from game window
-            return Task.FromResult<string?>(null);
+            // Capture a fixed 800x600 region from the top-left corner of the screen
+            Rectangle bounds = new Rectangle(0, 0, 800, 600);
+            using var bitmap = new Bitmap(bounds.Width, bounds.Height);
+            using (var g = Graphics.FromImage(bitmap))
+            {
+                g.CopyFromScreen(bounds.Location, Point.Empty, bounds.Size);
+            }
+
+            using var ms = new MemoryStream();
+            bitmap.Save(ms, SystemDrawingImageFormat.Png);
+            var bytes = ms.ToArray();
+            using var pix = Pix.LoadFromMemory(bytes);
+            using var page = _engine.Process(pix);
+            var text = page.GetText();
+            return Task.FromResult<string?>(string.IsNullOrWhiteSpace(text) ? null : text.Trim());
         }
     }
 }

--- a/src/GameTranslator.Infrastructure/Services/TranslationService.cs
+++ b/src/GameTranslator.Infrastructure/Services/TranslationService.cs
@@ -26,7 +26,18 @@ namespace GameTranslator.Infrastructure.Services
                 return cached;
             }
 
-            var response = await _httpClient.GetAsync($"https://api.example.com/translate?text={Uri.EscapeDataString(text)}&lang={targetLanguage}");
+            var request = new HttpRequestMessage(HttpMethod.Post, "https://libretranslate.de/translate")
+            {
+                Content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    q = text,
+                    source = "auto",
+                    target = targetLanguage,
+                    format = "text"
+                }), System.Text.Encoding.UTF8, "application/json")
+            };
+
+            var response = await _httpClient.SendAsync(request);
             response.EnsureSuccessStatusCode();
             var result = await response.Content.ReadAsStringAsync();
             var doc = JsonDocument.Parse(result);


### PR DESCRIPTION
## Summary
- implement OCR-based text capture using Tesseract
- integrate LibreTranslate API for translations
- include System.Drawing dependency

## Testing
- `dotnet test src/GameTranslator.Tests/GameTranslator.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_b_684d9ea5750c8333acb73ea985ecdf23